### PR TITLE
Bugfix/31 mobile view menu broken

### DIFF
--- a/e2e/theme.spec.js
+++ b/e2e/theme.spec.js
@@ -28,7 +28,6 @@ test.describe("Theme Switching", () => {
 
   test("should persist manual theme choice across reloads", async ({
     page,
-    context,
   }) => {
     await page.goto("/");
 

--- a/index.html
+++ b/index.html
@@ -645,7 +645,7 @@
       </div>
     </div>
 
-    <script src="/src/theme.js"></script>
-    <script src="/src/navigation.js"></script>
+    <script type="module" src="/src/theme.js"></script>
+    <script type="module" src="/src/navigation.js"></script>
   </body>
 </html>

--- a/src/style.css
+++ b/src/style.css
@@ -116,7 +116,8 @@
     padding-left: 1.5rem;
     padding-right: 1.5rem;
   }
-  .nav-links.open {
+  .nav-links.open,
+  .nav-links.active {
     opacity: 1;
     transform: translateY(0);
     visibility: visible;

--- a/time-tracker-privacy.html
+++ b/time-tracker-privacy.html
@@ -553,7 +553,7 @@
       </div>
     </footer>
 
-    <script src="/src/theme.js"></script>
-    <script src="/src/navigation.js"></script>
+    <script type="module" src="/src/theme.js"></script>
+    <script type="module" src="/src/navigation.js"></script>
   </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,6 +28,10 @@ export default defineConfig(({ mode }) => ({
     // Ensure CSS and JS are inlined for better performance on simple sites
     cssCodeSplit: false,
     rollupOptions: {
+      input: {
+        main: "./index.html",
+        "time-tracker-privacy": "./time-tracker-privacy.html",
+      },
       output: {
         // Customize asset file names
         assetFileNames: (assetInfo) => {


### PR DESCRIPTION
This PR fixes the mobile navigation menu on the time-tracker-privacy.html page by properly configuring the multi-page build setup and ensuring CSS supports both navigation modes. The fix addresses the issue where the mobile menu wasn't displaying when toggled on the privacy policy page.

Key changes:
- Configured Vite for multi-page application with both index.html and time-tracker-privacy.html as entry points
- Converted script tags to ES modules (`type="module"`) for proper Vite integration
- Extended CSS to support both `.nav-links.open` (index.html) and `.nav-links.active` (time-tracker-privacy.html) classes