### PR TITLE
Feature/35 timetracker eula

### DIFF
--- a/e2e/time-tracker-privacy.spec.js
+++ b/e2e/time-tracker-privacy.spec.js
@@ -62,12 +62,12 @@ test.describe("Time Tracker Privacy Policy Page", () => {
     await handleCookieConsent(page);
 
     // Check navigation links exist (use first to avoid strict mode violation)
-    const homeLink = page.locator('a[href="./#home"]').first();
+    const homeLink = page.locator('a[href="./index.html#home"]').first();
     await expect(homeLink).toBeVisible();
 
     // Click home link
     await homeLink.click();
-    await page.waitForURL("**/#home");
+    await page.waitForURL("**/index.html#home");
 
     // Verify we're on the main page
     await expect(page.locator(".hero")).toBeVisible();

--- a/e2e/time-tracker-terms.spec.js
+++ b/e2e/time-tracker-terms.spec.js
@@ -61,12 +61,12 @@ test.describe("Time Tracker Terms of Use Page", () => {
     await page.goto("/time-tracker-terms.html");
 
     // Check navigation links exist (use first to avoid strict mode violation)
-    const homeLink = page.locator('a[href="./#home"]').first();
+    const homeLink = page.locator('a[href="./index.html#home"]').first();
     await expect(homeLink).toBeVisible();
 
     // Click home link
     await homeLink.click();
-    await page.waitForURL("**/#home");
+    await page.waitForURL("**/index.html#home");
 
     // Verify we're on the main page
     await expect(page.locator(".hero")).toBeVisible();

--- a/time-tracker-privacy.html
+++ b/time-tracker-privacy.html
@@ -17,7 +17,7 @@
       <div class="container">
         <div class="logo">
           <a
-            href="./#home"
+            href="./index.html#home"
             style="text-decoration: none; display: flex; align-items: center"
           >
             <img
@@ -31,11 +31,11 @@
           <span class="menu-icon">&#9776;</span>
         </button>
         <ul class="nav-links" id="nav-links">
-          <li><a href="./#home">Home</a></li>
-          <li><a href="./#about-title">About</a></li>
-          <li><a href="./#services-title">Services</a></li>
-          <li><a href="./#projects-title">Projects</a></li>
-          <li><a href="./#contact-title">Contact</a></li>
+          <li><a href="./index.html#home">Home</a></li>
+          <li><a href="./index.html#about-title">About</a></li>
+          <li><a href="./index.html#services-title">Services</a></li>
+          <li><a href="./index.html#projects-title">Projects</a></li>
+          <li><a href="./index.html#contact-title">Contact</a></li>
         </ul>
         <button
           id="theme-toggle"

--- a/time-tracker-terms.html
+++ b/time-tracker-terms.html
@@ -17,7 +17,7 @@
       <div class="container">
         <div class="logo">
           <a
-            href="./#home"
+            href="./index.html#home"
             style="text-decoration: none; display: flex; align-items: center"
           >
             <img
@@ -31,11 +31,11 @@
           <span class="menu-icon">&#9776;</span>
         </button>
         <ul class="nav-links" id="nav-links">
-          <li><a href="./#home">Home</a></li>
-          <li><a href="./#about-title">About</a></li>
-          <li><a href="./#services-title">Services</a></li>
-          <li><a href="./#projects-title">Projects</a></li>
-          <li><a href="./#contact-title">Contact</a></li>
+          <li><a href="./index.html#home">Home</a></li>
+          <li><a href="./index.html#about-title">About</a></li>
+          <li><a href="./index.html#services-title">Services</a></li>
+          <li><a href="./index.html#projects-title">Projects</a></li>
+          <li><a href="./index.html#contact-title">Contact</a></li>
         </ul>
         <button
           id="theme-toggle"


### PR DESCRIPTION
Updates the Time Tracker legal pages so their navigation links correctly route back to the main landing page (`index.html`) instead of staying on the current document with an in-page hash.

**Changes:**
- Updated navbar logo + section links in `time-tracker-terms.html` to point to `./index.html#…`.
- Updated navbar logo + section links in `time-tracker-privacy.html` to point to `./index.html#…`.
- Adjusted Playwright E2E tests to locate the updated link targets and wait for the new URL.