### PR TITLE
Privacy policy does not disclose subscriptions, purchase data, or RevenueCat

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,0 +1,5 @@
+Invoke the `fix-issue` skill, passing `$ARGUMENTS` through unchanged.
+
+This file exists only so `/fix-issue` appears in the slash-command menu. The
+instructions live in `.claude/skills/fix-issue/SKILL.md` — follow those, not
+anything inferred from this file.

--- a/.claude/commands/fix-pr-comments.md
+++ b/.claude/commands/fix-pr-comments.md
@@ -1,0 +1,5 @@
+Invoke the `fix-pr-comments` skill, passing `$ARGUMENTS` through unchanged.
+
+This file exists only so `/fix-pr-comments` appears in the slash-command menu.
+The instructions live in `.claude/skills/fix-pr-comments/SKILL.md` — follow
+those, not anything inferred from this file.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: fix-issue
+description:
+  Fix a GitHub issue in this repo end to end — verify the issue's claims,
+  branch, implement, test, then stop for review before committing and opening a
+  PR into dev. Takes an issue number and any extra instructions.
+argument-hint: <issue-number> [extra instructions]
+---
+
+# Fix an issue
+
+Arguments: `$ARGUMENTS`. The first token is the issue number; anything after it
+is extra instruction from the user and overrides the defaults here.
+
+## 1. Read the issue, then check whether it is still true
+
+```bash
+gh issue view <N> --json title,body,labels,state -q '.title + "\n\n" + .body'
+```
+
+**Re-read every line the issue cites before acting on it.** The issue may have
+been written weeks ago against markup that has since moved, and a fix aimed at a
+stale quote is worse than no fix. That matters more than usual here: nearly all
+of the page lives in one big `index.html`, so line numbers drift constantly.
+
+If the issue turns out to be wrong or already fixed, say so and stop rather than
+inventing work to justify the ticket.
+
+Note what the issue explicitly puts out of scope, and what it lists as _related_
+issues — those usually touch the same file and are where a later conflict will
+land. Mention them in the PR rather than silently fixing them too.
+
+## 2. Branch
+
+Branch from the current branch by default, following the repo's convention —
+`feature/<N>-<short-kebab-slug>` for new work, `bugfix/<N>-<short-kebab-slug>`
+for a defect:
+
+```bash
+git checkout -b feature/<N>-<short-kebab-slug>
+```
+
+Before doing anything else, check how that base sits against the PR base:
+
+```bash
+git fetch origin
+git log --oneline origin/dev..HEAD
+```
+
+If that prints nothing, the two are level and there is nothing to think about.
+If it prints commits, **they will all appear in the PR diff** alongside the fix,
+because `dev` is the base the PR is opened against. Say so plainly — list what
+is being carried and ask whether to keep it or rebranch from `origin/dev` —
+before writing any code. Do not switch the base unasked.
+
+Carrying them is often right: a fix that builds on unmerged work has to. What is
+never right is carrying them without noticing. When the PR does stack on
+something, say in its body what it stacks on and why.
+
+Either way, name the base commit in your report so a wrong one is visible before
+the PR is opened rather than after.
+
+**Stay in this worktree** — never `git worktree add`. If you need to look at
+another branch, check it out here and switch back. Check the working tree is
+clean before switching; if it is not, ask rather than moving someone's
+uncommitted work.
+
+Never use bare `git stash` / `git stash pop`: the stash stack is shared with the
+main checkout and other sessions. Use a temporary WIP commit, or
+`git stash push -u -m "<unique-tag>"` and recover with `git stash apply <sha>`.
+
+## 3. Find the prior art before inventing anything
+
+`.github/copilot-instructions.md` is the architecture summary for this repo —
+read it first. The longer-form docs are worth knowing:
+
+- `TESTING.md` and `E2E_TESTING_GUIDE.md` — the unit and E2E strategy, and the
+  shared helpers the specs expect you to reuse.
+- `COOKIES.md` and `GOOGLE_ANALYTICS.md` — the consent model and the GA
+  Consent Mode v2 wiring. Anything touching tracking, consent, or the cookie
+  dialog has a documented answer already; do not improvise a new one.
+
+The shape of the codebase:
+
+- `index.html` holds the page content **and** its JavaScript inline. New
+  behaviour usually belongs in the existing inline script, not a new module,
+  unless the issue asks for extraction.
+- `src/style.css` is the single stylesheet, driven by CSS custom properties
+  (`--smooth-ease`, `--smooth-duration`). It is mobile-first with one
+  consolidated `@media (max-width: 600px)` block — put responsive rules there
+  rather than opening a second breakpoint.
+- The theme system persists to `localStorage` with a system-preference
+  fallback, and a theme switch updates several assets at once (GitHub and
+  LinkedIn icons, favicon). Miss one and the visual snapshots catch it.
+- Static assets live in `public/images/` in size- and format-specific
+  subdirectories.
+
+## 4. Implement
+
+Things in this repo that bite:
+
+- **Consent first.** No analytics call, script tag, or cookie may fire ahead of
+  consent. If a change adds anything that touches GA, walk through the
+  denied-consent path explicitly and say in the report that you did.
+- **GA has three modes** — development (`GA-DEVELOPMENT-MODE`, console-logged),
+  test (`GA-TEST-MODE`, injected by `vitest.config.js`), and the real
+  production id substituted at build time by `@rollup/plugin-replace`. A change
+  that only works in one of the three is a bug.
+- **Visual snapshots are committed.** `e2e/theme.spec.js-snapshots/` holds
+  per-browser, per-platform PNGs (`*-linux.png`). Any deliberate visual change
+  needs them regenerated — `npx playwright test --update-snapshots` — and the
+  regenerated files belong in the PR. Say plainly that they were regenerated,
+  and never update a snapshot to silence a failure you have not explained.
+- **Mobile is a distinct code path**, not just narrower CSS: the hamburger menu
+  is absolutely positioned and the E2E specs drive it through
+  `ensureMobileMenuOpen()` / `clickMobileNavLink()`. Check a nav change on both.
+
+## 5. Verify
+
+```bash
+npm run format        # prettier, writes
+npm run lint          # stylelint + eslint; must be clean
+npm run test:run      # vitest, non-watch
+npm run test:e2e      # playwright; slower — chromium, firefox, Mobile Chrome
+```
+
+`npm test` alone starts vitest in **watch mode** and will hang a non-interactive
+run — always use `test:run`.
+
+If Playwright complains about missing browsers:
+`npx playwright install --with-deps chromium firefox`.
+
+Add tests for the actual defect, in the existing file for that area —
+`src/test/*.test.js` for unit (jsdom, with global mocks in
+`src/test/setup.js`), `e2e/*.spec.js` for end-to-end. Reuse the existing
+helpers, `handleCookieConsent()` above all: an E2E spec that does not dismiss
+the consent dialog fails for the wrong reason.
+
+## 6. Stop. Do not commit.
+
+Report what changed and **leave everything as unstaged modifications**. The user
+reviews in the VS Code Source Control panel, which reads the working tree — a
+commit empties it and the review step silently disappears.
+
+In the report:
+
+- Point at the two or three hunks most worth scrutiny, by `file:line`.
+- Call out anything **beyond the issue's scope** you did anyway, and offer to
+  cut it.
+- Call out anything **irreversible** and why you chose it now — regenerated
+  visual snapshots count.
+- Say what you could not verify yourself.
+
+If a commit was already made by mistake:
+`git reset --soft HEAD~1 && git restore --staged .`
+
+## 7. On an explicit go-ahead: commit, push, PR
+
+Commit message: `type(scope): summary (#N)` — a body explaining _why_, wrapped
+at ~72 columns, ending with:
+
+```
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+```
+
+Then push and open the PR **into `dev`**, not `main`:
+
+```bash
+git push -u origin <branch>
+gh pr create --base dev --title "..." --body-file <file>
+```
+
+`dev` is promoted to `main` separately, by its own PR, and pushing to `main` is
+what deploys the live site. Never open a fix PR straight into `main`.
+
+Write the body to a scratchpad file rather than passing it inline. Include
+`Closes #<N>`, the reasoning, what you left out, and the same scope flags from
+the review report. End with:
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+If `gh pr edit` fails on a Projects-classic deprecation (it does in the sibling
+`time_tracker` repo), amend the PR with:
+
+```bash
+gh api -X PATCH repos/lightofdata/website/pulls/<n> -f body=@<file>
+```
+
+CI (`.github/workflows/validate.yml`) runs on PRs to `main` and `dev`: build,
+`format:check`, `lint`, `test:run`, then E2E on chromium and firefox. It does
+**not** run WebKit — `test:e2e:webkit` is opt-in behind `ENABLE_WEBKIT=true`,
+so a Safari-only bug will pass CI. If the fix can only be observed on a real
+device or in Safari, say that plainly rather than letting a green check imply
+otherwise.

--- a/.claude/skills/fix-pr-comments/SKILL.md
+++ b/.claude/skills/fix-pr-comments/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: fix-pr-comments
+description:
+  Fetch the unresolved review threads on a pull request and address them, then
+  stop for review before committing. Defaults to the current branch's PR; takes
+  an optional PR number and any extra instructions.
+argument-hint: "[pr-number] [extra instructions]"
+---
+
+# Fix PR review comments
+
+Arguments: `$ARGUMENTS`. A leading number is the PR to work on; anything else is
+extra instruction from the user and overrides the defaults here. With no
+arguments, use the current branch's PR.
+
+## 1. Find the PR
+
+With a PR number in the arguments, pass it explicitly — without it `gh pr view`
+falls back to the current branch's PR, which is the wrong one:
+
+```bash
+gh pr view <N> --json number,baseRefName,headRefName
+```
+
+With no PR number, omit it and take the current branch's PR:
+
+```bash
+gh pr view --json number,baseRefName,headRefName
+```
+
+If no PR exists for this branch, say so and stop — do not create one.
+
+Make sure the working tree is on that PR's head branch before editing anything.
+**Stay in this worktree**; never `git worktree add`.
+
+## 2. Fetch the unresolved threads
+
+Substitute the `number` from step 1 for `NUMBER`:
+
+```bash
+gh api graphql -f query='
+{ repository(owner: "lightofdata", name: "website") {
+    pullRequest(number: NUMBER) {
+      reviewThreads(first: 100) { nodes {
+        id isResolved isOutdated path line
+        comments(first: 10) { nodes { body author { login } } }
+      } }
+    } } }'
+```
+
+Filter to `isResolved == false`. If there are none, say so and stop.
+
+Keep each thread's `id` — it is what a reply or a resolve needs later.
+
+`isOutdated` threads point at code that has since moved. Read the current file
+before deciding whether the comment still applies; an outdated thread is often
+already handled, and saying so is a better answer than editing around it. Expect
+plenty of these on `index.html`, where almost everything shares one file and
+line numbers shift under any edit.
+
+## 3. Work each thread
+
+For every unresolved thread: read the file at that line **with surrounding
+context**, understand what the reviewer is actually asking for, and fix the
+cause rather than the symptom.
+
+A review comment is a hypothesis, not an instruction. If the reviewer is
+mistaken, or the fix they suggest would break something they could not see from
+the diff, do not silently comply — make the case in your report and let the user
+decide. Note it and move on; do not argue in the PR thread unasked.
+
+Follow the house conventions in the `fix-issue` skill for anything the change
+touches — in particular the consent-before-analytics rule, the single
+`@media (max-width: 600px)` breakpoint, and the committed visual snapshots
+under `e2e/theme.spec.js-snapshots/`. A review comment asking for a visual
+tweak means those snapshots need regenerating in the same push.
+
+## 4. Verify
+
+```bash
+npm run format        # prettier, writes
+npm run lint          # stylelint + eslint; must be clean
+npm run test:run      # vitest, non-watch — never bare `npm test` (watch mode)
+npm run test:e2e      # playwright; slower
+```
+
+## 5. Stop. Do not commit.
+
+Leave everything as unstaged modifications. The user reviews in the VS Code
+Source Control panel, which reads the working tree — a commit empties it and the
+review step silently disappears.
+
+Report one line per thread: the reviewer, the file, what you changed, and
+explicitly which threads you **did not** act on and why. Flag anything you could
+not verify yourself — Safari behaviour in particular, since CI does not run
+WebKit.
+
+If a commit was already made by mistake:
+`git reset --soft HEAD~1 && git restore --staged .`
+
+## 6. On an explicit go-ahead
+
+Commit and push to the existing PR branch. Message format and the
+`Co-Authored-By` trailer are in the `fix-issue` skill — follow it rather than
+reinventing them.
+
+Do not resolve the threads yourself unless the user asks. Replying to or
+resolving a thread is a message to the reviewer in the user's name, and that is
+theirs to send.

--- a/e2e/time-tracker-privacy.spec.js
+++ b/e2e/time-tracker-privacy.spec.js
@@ -52,7 +52,7 @@ test.describe("Time Tracker Privacy Policy Page", () => {
     // Check for date information
     const content = await page.textContent("body");
     expect(content).toContain("Last Updated");
-    expect(content).toContain("June 15, 2026");
+    expect(content).toContain("August 23, 2026");
   });
 
   test("should have working navigation back to main site", async ({ page }) => {
@@ -356,6 +356,38 @@ test.describe("Privacy Policy Content Quality", () => {
     expect(content).toContain("days");
   });
 
+  test("should disclose subscription and purchase data", async ({ page }) => {
+    await page.goto("/time-tracker-privacy.html");
+
+    // Handle cookie consent
+    await handleCookieConsent(page);
+
+    // The subscription subsection must exist under Information We Collect
+    await expect(
+      page.getByRole("heading", { name: /Subscription and Purchase/i })
+    ).toBeVisible();
+
+    // Source wraps prose across lines, so compare on collapsed whitespace
+    const content = (await page.textContent("body")).replace(/\s+/g, " ");
+
+    // Purchase data collection, and who processes it
+    expect(content).toContain("RevenueCat");
+    expect(content).toContain("Purchase history");
+    expect(content).toContain("seller of record");
+
+    // The two claims the stores look for
+    expect(content).toContain("We never receive or store your payment details");
+    expect(content).toContain("does not cancel a subscription");
+
+    // RevenueCat policy link, opened safely
+    const revenueCatLink = page.locator(
+      'a[href="https://www.revenuecat.com/privacy"]'
+    );
+    await expect(revenueCatLink).toBeVisible();
+    expect(await revenueCatLink.getAttribute("rel")).toContain("noopener");
+    expect(await revenueCatLink.getAttribute("target")).toBe("_blank");
+  });
+
   test("should explain data collection clearly", async ({ page }) => {
     await page.goto("/time-tracker-privacy.html");
 
@@ -368,6 +400,19 @@ test.describe("Privacy Policy Content Quality", () => {
     ).toBeVisible();
     await expect(
       page.getByRole("heading", { name: /Time Tracking Data/i })
+    ).toBeVisible();
+
+    // Source wraps prose across lines, so compare on collapsed whitespace
+    const content = (await page.textContent("body")).replace(/\s+/g, " ");
+
+    // Crash reporting is disclosed, and the no-analytics claim is explicit
+    expect(content).toContain("Firebase Crashlytics");
+    expect(content).toContain("does not use an analytics SDK");
+
+    // Google account access is for calendar only, and revocable
+    expect(content).toContain("it is not how you sign in");
+    await expect(
+      page.locator('a[href="https://myaccount.google.com/permissions"]')
     ).toBeVisible();
   });
 });

--- a/time-tracker-privacy.html
+++ b/time-tracker-privacy.html
@@ -65,7 +65,7 @@
       <h1>Privacy Policy for Time Tracker</h1>
 
       <p style="font-style: italic; opacity: 0.7; margin-bottom: 2rem">
-        <strong>Last Updated:</strong> June 15, 2026
+        <strong>Last Updated:</strong> August 23, 2026
       </p>
 
       <h2>Introduction</h2>
@@ -156,6 +156,12 @@
         <li>App version information</li>
         <li>Error logs and crash reports (to improve app stability)</li>
       </ul>
+      <p>
+        Crash reports and error logs are collected through Firebase Crashlytics,
+        which receives a crash stack trace together with basic device and app
+        information. The app does not use an analytics SDK, and we do not
+        collect screen views, feature usage, or other behavioural analytics.
+      </p>
 
       <h3>5. Local Storage</h3>
       <p>The app uses local storage on your device to:</p>
@@ -164,6 +170,43 @@
         <li>Store app preferences and settings</li>
         <li>Enable offline time tracking</li>
       </ul>
+
+      <h3>6. Subscription and Purchase Information</h3>
+      <p>
+        Time Tracker offers an optional paid subscription. If you subscribe, we
+        collect:
+      </p>
+      <ul>
+        <li>Your subscription status, plan, and renewal or expiry dates</li>
+        <li>
+          Purchase history for this app, including transaction identifiers
+        </li>
+        <li>
+          A pseudonymous app user identifier, which is the same account
+          identifier used to store your time tracking data
+        </li>
+      </ul>
+      <p>
+        <strong>We never receive or store your payment details.</strong> Card
+        numbers, billing addresses, and similar payment information are handled
+        entirely by Apple or Google as the seller of record, and are never sent
+        to us.
+      </p>
+      <p>
+        We use RevenueCat to record which accounts hold an active subscription.
+        When you sign in, the app sends your Time Tracker account identifier to
+        RevenueCat so your subscription follows your account across your devices
+        and can be restored after a reinstall. Your email address and name are
+        not sent. RevenueCat also receives purchase and subscription details
+        from Apple and Google, together with basic device and app information
+        collected by its SDK.
+      </p>
+      <p>
+        <strong
+          >Subscribing is optional. If you never subscribe, no purchase
+          information is collected.</strong
+        >
+      </p>
 
       <h2>How We Use Your Information</h2>
       <p>We use the collected information to:</p>
@@ -187,6 +230,15 @@
         <li>
           <strong>Authentication:</strong> Verify your identity using your email
           and password
+        </li>
+        <li>
+          <strong>Improve Stability:</strong> Use crash reports and error logs
+          to diagnose and fix bugs
+        </li>
+        <li>
+          <strong>Subscription Management:</strong> Determine whether your
+          account has an active subscription, unlock paid features, and restore
+          previous purchases
         </li>
       </ol>
 
@@ -217,8 +269,9 @@
           your device and our servers uses HTTPS/TLS encryption
         </li>
         <li>
-          <strong>Authentication:</strong> Secure authentication with encrypted
-          password storage
+          <strong>Authentication:</strong> Handled by Supabase Auth. Your
+          password is sent to Supabase over an encrypted connection and is never
+          stored by the app on your device
         </li>
         <li>
           <strong>Database Security:</strong> Supabase provides row-level
@@ -245,6 +298,15 @@
           <strong>Local Data:</strong> Cached data on your device is deleted
           when you uninstall the app or clear app data
         </li>
+        <li>
+          <strong>Subscription Records:</strong> Purchase and subscription
+          records are retained by RevenueCat and by Apple or Google for as long
+          as required for billing, tax, and dispute-resolution purposes, which
+          may be longer than the 30-day deletion window above. Deleting your
+          Time Tracker account removes your data from our servers but does not
+          cancel a subscription &mdash; cancel that through your Apple or Google
+          account.
+        </li>
       </ul>
 
       <h2>Data Sharing and Third Parties</h2>
@@ -260,8 +322,11 @@
       <h3>Third-Party Services We Use</h3>
       <ol>
         <li>
-          <strong>Supabase:</strong> For cloud data storage and synchronization
-          (<a href="https://supabase.com/privacy" target="_blank" rel="noopener"
+          <strong>Supabase:</strong> For cloud data storage, synchronization,
+          and authentication (<a
+            href="https://supabase.com/privacy"
+            target="_blank"
+            rel="noopener"
             >Supabase Privacy Policy</a
           >)
         </li>
@@ -290,6 +355,30 @@
             target="_blank"
             rel="noopener"
             >Google API Services User Data Policy</a
+          >)
+        </li>
+        <li>
+          <strong>RevenueCat:</strong> For managing subscription status and
+          restoring purchases (<a
+            href="https://www.revenuecat.com/privacy"
+            target="_blank"
+            rel="noopener"
+            >RevenueCat Privacy Policy</a
+          >)
+        </li>
+        <li>
+          <strong>Apple App Store and Google Play:</strong> As the payment
+          processors and sellers of record for subscriptions (<a
+            href="https://www.apple.com/legal/privacy/"
+            target="_blank"
+            rel="noopener"
+            >Apple Privacy Policy</a
+          >,
+          <a
+            href="https://policies.google.com/privacy"
+            target="_blank"
+            rel="noopener"
+            >Google Privacy Policy</a
           >)
         </li>
       </ol>
@@ -333,6 +422,23 @@
         </li>
         <li>Choose which calendars to sync with</li>
       </ul>
+      <p>
+        Granting calendar access is the only thing Time Tracker uses your Google
+        account for &mdash; it is not how you sign in. To revoke that access:
+      </p>
+      <ol>
+        <li>
+          Visit your
+          <a
+            href="https://myaccount.google.com/permissions"
+            target="_blank"
+            rel="noopener"
+            >Google Account settings</a
+          >
+        </li>
+        <li>Find "Time Tracker" in the list of apps</li>
+        <li>Click "Remove Access"</li>
+      </ol>
 
       <h2>Children's Privacy</h2>
       <p>


### PR DESCRIPTION
Updates the Time Tracker privacy policy page to reflect current disclosures (crash reporting, subscriptions/purchases, auth handling, and Google Calendar revocation steps) and extends Playwright coverage to lock in the new required language.

**Changes:**
- Refreshes the “Last Updated” date and expands privacy policy disclosures for Crashlytics, RevenueCat subscriptions/purchases, and Supabase Auth.
- Adds/updates sections covering subscription data collection/retention and Google Account permission revocation steps for calendar access.
- Adds new E2E assertions to ensure the subscription disclosure, crash reporting/no-analytics statement, and RevenueCat link requirements remain present.